### PR TITLE
Map Subject, ReplyTo and PartitionKey properties on ServiceBusReceivedMessage creation

### DIFF
--- a/src/Spotflow.InMemory.Azure.ServiceBus/Internals/MessagesStore.cs
+++ b/src/Spotflow.InMemory.Azure.ServiceBus/Internals/MessagesStore.cs
@@ -232,8 +232,6 @@ internal class MessagesStore(TimeProvider timeProvider, TimeSpan lockTime)
             throw new InvalidOperationException($"Unsupported receive mode: {receiveMode}.");
         }
 
-
-
         return ServiceBusModelFactory.ServiceBusReceivedMessage(
               body: message.Body,
               messageId: message.MessageId,
@@ -244,11 +242,11 @@ internal class MessagesStore(TimeProvider timeProvider, TimeSpan lockTime)
               contentType: message.ContentType,
               enqueuedTime: timeProvider.GetUtcNow(),
               properties: message.ApplicationProperties,
+              subject: message.Subject,
               lockTokenGuid: lockToken,
               lockedUntil: lockedUntil,
               sequenceNumber: sequenceNumber
               );
-
     }
 
     private void ReleaseExpiredMessagesUnsafe()

--- a/src/Spotflow.InMemory.Azure.ServiceBus/Internals/MessagesStore.cs
+++ b/src/Spotflow.InMemory.Azure.ServiceBus/Internals/MessagesStore.cs
@@ -237,6 +237,7 @@ internal class MessagesStore(TimeProvider timeProvider, TimeSpan lockTime)
               messageId: message.MessageId,
               sessionId: message.SessionId,
               replyToSessionId: message.ReplyToSessionId,
+              replyTo: message.ReplyTo,
               timeToLive: message.TimeToLive,
               correlationId: message.CorrelationId,
               contentType: message.ContentType,
@@ -245,7 +246,8 @@ internal class MessagesStore(TimeProvider timeProvider, TimeSpan lockTime)
               subject: message.Subject,
               lockTokenGuid: lockToken,
               lockedUntil: lockedUntil,
-              sequenceNumber: sequenceNumber
+              sequenceNumber: sequenceNumber,
+              partitionKey: message.PartitionKey
               );
     }
 

--- a/tests/Tests/ServiceBus/ServiceBusReceiverTests.cs
+++ b/tests/Tests/ServiceBus/ServiceBusReceiverTests.cs
@@ -303,12 +303,12 @@ public class ServiceBusReceiverTests
         receivedMessage.ApplicationProperties.Count.Should().Be(1);
         receivedMessage.ApplicationProperties["test-app-property"].Should().Be("test-app-property-value");
 
-        //receivedMessage.Subject.Should().Be("test-subject");
+        receivedMessage.Subject.Should().Be("test-subject");
         receivedMessage.ContentType.Should().Be("test-content-type");
         receivedMessage.CorrelationId.Should().Be("test-correlation-id");
         receivedMessage.MessageId.Should().Be("test-message-id");
-        //receivedMessage.PartitionKey.Should().Be("test-partition-key");
-        //receivedMessage.ReplyTo.Should().Be("test-reply-to");
+        receivedMessage.PartitionKey.Should().Be("test-partition-key");
+        receivedMessage.ReplyTo.Should().Be("test-reply-to");
         receivedMessage.ReplyToSessionId.Should().Be("test-reply-to-session-id");
 
         receivedMessage.EnqueuedTime.Should().Be(timeProvider.GetUtcNow());


### PR DESCRIPTION
I added mapping for the `Subject` property that are the only missing property from the `ServiceBusReceivedMessage` creation. I use the message subject to identify what the payload contains in my application, 